### PR TITLE
Fix namespace names for TimerSession and TimerController

### DIFF
--- a/myPomodoro/WebApplication1/Controllers/TimerController.cs
+++ b/myPomodoro/WebApplication1/Controllers/TimerController.cs
@@ -2,9 +2,9 @@
 using System.Net;
 using System.Net.Mail;
 using System.Text;
-using YourProject.Models;
+using WebApplication1.Models;
 
-namespace YourProject.Controllers
+namespace WebApplication1.Controllers
 {
     public class TimerController : Controller
     {

--- a/myPomodoro/WebApplication1/Models/TimerSession.cs
+++ b/myPomodoro/WebApplication1/Models/TimerSession.cs
@@ -1,4 +1,4 @@
-﻿namespace YourProject.Models
+﻿namespace WebApplication1.Models
 {
     public class TimerSession
     {


### PR DESCRIPTION
## Summary
- align namespaces with `WebApplication1.*`

## Testing
- `dotnet build myPomodoro/myPomodoro.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842244109a0833097cc455f50b5bc2e