### PR TITLE
Improve Timer UI and responsiveness

### DIFF
--- a/myPomodoro/WebApplication1/Views/Timer/Index.cshtml
+++ b/myPomodoro/WebApplication1/Views/Timer/Index.cshtml
@@ -7,45 +7,42 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
 
-<div class="modal fade show d-block" tabindex="-1" role="dialog"
-     style="background-color: rgba(0,0,0,0.8);" aria-modal="true">
+<div class="modal fade show d-block timer-modal" tabindex="-1" role="dialog" aria-modal="true">
     <div class="modal-dialog modal-fullscreen" role="document">
-        <div class="modal-content text-center" style="background-color: #f7f7f7;">
+        <div class="modal-content text-center timer-content">
 
             <!-- [1] Header -->
             <div class="modal-header">
-                <h1 class="modal-title w-100" style="font-size: 2rem;">Pomodoro-Style Timer</h1>
+                <h1 class="modal-title w-100 fs-2">Pomodoro-Style Timer</h1>
             </div>
 
             <!-- [2] Body -->
-            <div class="modal-body" style="height: 75vh;">
-                <div class="row w-100 h-100">
+            <div class="modal-body timer-body">
+                <div class="row flex-column flex-md-row w-100 h-100">
 
                     <!-- Left Column (Timer) -->
-                    <div class="col-md-8 d-flex flex-column align-items-center justify-content-center">
+                    <div class="col-12 col-md-8 d-flex flex-column align-items-center justify-content-center">
 
                         <!-- Timer Display -->
-                        <div id="timer-display" style="font-size: 5rem; margin-bottom: 1rem;">00:00</div>
+                        <div id="timer-display" class="timer-display">00:00</div>
 
                         <!-- Session Label (Work / Break) -->
-                        <div id="session-label" style="font-size: 1.25rem; margin-bottom: 1rem;">Work Session</div>
+                        <div id="session-label">Work Session</div>
 
                         <!-- Duration controls -->
                         <div class="mb-3">
                             <label for="workDuration" class="form-label">Work Session (minutes):</label>
-                            <input type="number" id="workDuration" class="form-control"
-                                   style="width:200px; margin: 0 auto;" value="30" />
+                            <input type="number" id="workDuration" class="form-control timer-input" value="30" />
                         </div>
                         <div class="mb-3">
                             <label for="restDuration" class="form-label">Rest Session (minutes):</label>
-                            <input type="number" id="restDuration" class="form-control"
-                                   style="width:200px; margin: 0 auto;" value="5" />
+                            <input type="number" id="restDuration" class="form-control timer-input" value="5" />
                         </div>
 
                         <!-- Category (Job/Personal) -->
                         <div class="mb-3">
                             <label for="taskCategory" class="form-label">Select Task Category:</label>
-                            <select id="taskCategory" class="form-select" style="width:200px; margin:0 auto;">
+                            <select id="taskCategory" class="form-select timer-input">
                                 <option value="">(None)</option>
                                 <option value="Job">Job</option>
                                 <option value="Personal">Personal</option>
@@ -61,57 +58,60 @@
                         </div>
 
                         <!-- Completed 30-min sessions -->
-                        <div class="mt-4">
-                            <span style="font-size: 1.5rem;">30-min Sessions Completed:</span>
-                            <span id="completed-sessions" style="font-size: 2rem;">0</span>
+                        <div class="mt-4 w-100">
+                            <label class="form-label">30-min Sessions Completed</label>
+                            <div class="progress">
+                                <div id="completed-sessions" class="progress-bar" role="progressbar"
+                                     style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="8">0</div>
+                            </div>
                         </div>
                     </div>
 
                     <!-- Right Column: Focus Metrics + Weekly Chart -->
-                    <div class="col-md-4 d-flex flex-column align-items-center">
-                        <div class="card w-100" style="margin-bottom: 1rem;">
+                    <div class="col-12 col-md-4 d-flex flex-column align-items-center">
+                        <div class="card w-100 mb-3">
                             <div class="card-body">
                                 <h5 class="card-title">Focus Metrics</h5>
 
                                 <p>
                                     <strong>Today's Improvement:</strong>
-                                    <span id="improvement-percentage" style="font-size: 1.25rem;">+0%</span>
+                                    <span id="improvement-percentage" class="fs-5">+0%</span>
                                 </p>
                                 <p>
                                     <strong>Today's Job Volume (min):</strong>
-                                    <span id="today-job-volume" style="font-size: 1.25rem;">0</span>
+                                    <span id="today-job-volume" class="fs-5">0</span>
                                 </p>
                                 <p>
                                     <strong>Last Work Day's Job Volume (min):</strong>
-                                    <span id="prev-job-volume" style="font-size: 1.25rem;">0</span>
+                                    <span id="prev-job-volume" class="fs-5">0</span>
                                 </p>
                                 <p>
                                     <strong>Today's Personal Volume (min):</strong>
-                                    <span id="today-personal-volume" style="font-size: 1.25rem;">0</span>
+                                    <span id="today-personal-volume" class="fs-5">0</span>
                                 </p>
                                 <p>
                                     <strong>Last Work Day's Personal Volume (min):</strong>
-                                    <span id="prev-personal-volume" style="font-size: 1.25rem;">0</span>
+                                    <span id="prev-personal-volume" class="fs-5">0</span>
                                 </p>
                                 <p>
                                     <strong>Focus Rating:</strong>
-                                    <span id="self-intensity" style="font-size: 1.25rem;">N/A</span>
+                                    <span id="self-intensity" class="fs-5">N/A</span>
                                 </p>
 
                                 <!-- 5 Star Rating -->
-                                <div id="starRating" style="margin-bottom: 1rem;">
-                                    <i class="fa-solid fa-star" data-value="1"></i>
-                                    <i class="fa-solid fa-star" data-value="2"></i>
-                                    <i class="fa-solid fa-star" data-value="3"></i>
-                                    <i class="fa-solid fa-star" data-value="4"></i>
-                                    <i class="fa-solid fa-star" data-value="5"></i>
+                                <div id="starRating" class="mb-3">
+                                    <i class="fa-solid fa-star text-muted" data-value="1"></i>
+                                    <i class="fa-solid fa-star text-muted" data-value="2"></i>
+                                    <i class="fa-solid fa-star text-muted" data-value="3"></i>
+                                    <i class="fa-solid fa-star text-muted" data-value="4"></i>
+                                    <i class="fa-solid fa-star text-muted" data-value="5"></i>
                                 </div>
                                 <button id="saveRatingBtn" class="btn btn-secondary btn-sm">Save Rating</button>
                             </div>
                         </div>
 
                         <!-- Last 7 Days Chart -->
-                        <div style="width: 90%;">
+                        <div class="w-100">
                             <h5>Weekly Chart (Last 7 Days)</h5>
                             <canvas id="myChart" width="300" height="300"></canvas>
                         </div>

--- a/myPomodoro/WebApplication1/wwwroot/css/site.css
+++ b/myPomodoro/WebApplication1/wwwroot/css/site.css
@@ -20,3 +20,37 @@ html {
 body {
   margin-bottom: 60px;
 }
+
+/* Timer page styles */
+.timer-modal {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+.timer-content {
+  background-color: #f7f7f7;
+}
+
+.timer-body {
+  height: 75vh;
+}
+
+.timer-display {
+  font-size: 5rem;
+  margin-bottom: 1rem;
+}
+
+#session-label {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.timer-input {
+  width: 200px;
+  margin: 0 auto;
+}
+
+@media (max-width: 767.98px) {
+  .timer-display {
+    font-size: 3rem;
+  }
+}

--- a/myPomodoro/WebApplication1/wwwroot/js/pomodoro.js
+++ b/myPomodoro/WebApplication1/wwwroot/js/pomodoro.js
@@ -21,6 +21,7 @@
     const recordBtn = document.getElementById("record-btn");
     const saveRatingBtn = document.getElementById("saveRatingBtn");
     const stars = document.querySelectorAll("#starRating i");
+    const completedSessionsEl = document.getElementById("completed-sessions");
 
     // On page load, fetch improvement stats & chart data
     window.onload = () => {
@@ -97,7 +98,9 @@
         updateDisplay(0);
         updateStarDisplay(0);
         sessionLabelEl.textContent = "Work Session";
-        document.getElementById("completed-sessions").textContent = "0";
+        completedSessionsEl.textContent = "0";
+        completedSessionsEl.style.width = "0%";
+        completedSessionsEl.setAttribute("aria-valuenow", "0");
     }
 
     function startInterval() {
@@ -114,7 +117,10 @@
 
                     if (isWorkSession && usedMin === 30) {
                         thirtyMinSessionCount++;
-                        document.getElementById("completed-sessions").textContent = thirtyMinSessionCount;
+                        completedSessionsEl.textContent = thirtyMinSessionCount;
+                        const progress = Math.min(thirtyMinSessionCount, 8);
+                        completedSessionsEl.style.width = `${progress * 12.5}%`;
+                        completedSessionsEl.setAttribute("aria-valuenow", progress.toString());
                     }
 
                     // auto-record if it's a finished work session
@@ -230,8 +236,9 @@
 
     function updateStarDisplay(rating) {
         stars.forEach(star => {
-            let val = parseInt(star.getAttribute("data-value"));
-            star.style.color = (val <= rating) ? "gold" : "gray";
+            const val = parseInt(star.getAttribute("data-value"));
+            star.classList.toggle("text-warning", val <= rating);
+            star.classList.toggle("text-muted", val > rating);
         });
     }
 


### PR DESCRIPTION
## Summary
- move Timer page styling to CSS
- make layout responsive and mobile-friendly
- convert session counter to progress bar
- use Bootstrap classes for star rating

## Testing
- `dotnet test myPomodoro/myPomodoro.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423f38b3fc8330a5db123d9452edab