### PR TITLE
Fix timer layout centering

### DIFF
--- a/myPomodoro/WebApplication1/Views/Timer/Index.cshtml
+++ b/myPomodoro/WebApplication1/Views/Timer/Index.cshtml
@@ -20,7 +20,7 @@
 
             <!-- [2] Body -->
             <div class="modal-body timer-body">
-                <div class="row flex-column flex-md-row w-100 h-100">
+                <div class="row flex-column flex-md-row w-100 h-100 justify-content-center align-items-center">
 
                     <!-- Left Column (Timer) -->
                     <div class="col-12 col-md-8 d-flex flex-column align-items-center justify-content-center">
@@ -71,7 +71,7 @@
                     </div>
 
                     <!-- Right Column: Focus Metrics + Weekly Chart -->
-                    <div class="col-12 col-md-4 d-flex flex-column align-items-center">
+                    <div class="col-12 col-md-4 d-flex flex-column align-items-center justify-content-center">
 
                         <div class="card w-100 mb-4 shadow-sm">
 

--- a/myPomodoro/WebApplication1/wwwroot/css/site.css
+++ b/myPomodoro/WebApplication1/wwwroot/css/site.css
@@ -31,6 +31,9 @@ body {
 }
 
 .timer-body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   height: 75vh;
 }
 


### PR DESCRIPTION
## Summary
- center timer and metrics vertically and horizontally

## Testing
- `dotnet test myPomodoro/myPomodoro.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684242b799d48330ba6d95865404b736